### PR TITLE
Feature: Make build.xml compatible with ant.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+build
+dist
+
+# Created by https://www.gitignore.io/api/osx
+
+### OSX ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+# End of https://www.gitignore.io/api/osx

--- a/build.xml
+++ b/build.xml
@@ -1,14 +1,35 @@
 <?xml version="1.0" ?>
-<!-- Configuration of the Ant build system to generate a Jar file --> 
-<project name="HTTP Smuggler" default="CreateJar">
-	<property name="projectHome" location="." />
-	<target name="CreateJar" description="Create Jar file">
-		<jar destfile="${projectHome}/httpsmuggler.jar" basedir="${projectHome}/bin">
-			<!--<zipgroupfileset dir="libs/" includes="*.jar" excludes=""/>-->
-			
-			<fileset dir=".">
-			    <include name="**/resources//**"/>
-			</fileset>
-		</jar>
+<!-- Configuration of the Ant build system to generate a Jar file -->
+<project name="HTTP Smuggler" default="dist">
+	<property name="src" location="src"/>
+	<property name="build" location="build"/>
+	<property name="dist" location="dist"/>
+
+	<target name="clean">
+		<delete dir="${build}"/>
+	</target>
+
+	<target name="init">
+		<!-- Create the time stamp -->
+		<tstamp/>
+		<!-- Create the build directory structure used by compile -->
+		<mkdir dir="${build}"/>
+	</target>
+
+
+	<target name="compile" depends="init" description="compile the source">
+		<!-- Compile the Java code from ${src} into ${build} -->
+		<javac srcdir="${src}" destdir="${build}"/>
+		<copy todir="${build}/resources">
+            <fileset dir="${src}/resources"/>
+        </copy>
+	</target>
+
+	<target name="dist" depends="compile" description="generate the distribution">
+		<!-- Create the distribution directory -->
+		<mkdir dir="${dist}/lib"/>
+
+		<!-- Put everything in ${build} into the burp-httpsmuggler-${DSTAMP}.jar file -->
+		<jar jarfile="${dist}/lib/burp-httpsmuggler-${DSTAMP}.jar" basedir="${build}" />
 	</target>
 </project>


### PR DESCRIPTION
After checking out the repository I wasn't able to build the jar file with ant. It looks like the project was built using eclipse and the default build.xml was never updated for compatibility. 

Because I don't have eclipse and the build.xml doesn't seem to be used I made it compatible with `ant`.

Example usage:
```
$ ant
Buildfile: /home/burpsuite/extensions/BurpSuiteHTTPSmuggler/build.xml

init:
    [mkdir] Created dir: /home/burpsuite/extensions/BurpSuiteHTTPSmuggler/build

compile:
    [javac] Compiling 52 source files to /home/burpsuite/extensions/BurpSuiteHTTPSmuggler/build
    [javac] Note: Some input files use unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.
     [copy] Copying 1 file to /home/burpsuite/extensions/BurpSuiteHTTPSmuggler/build/resources

dist:
      [jar] Building jar: /home/burpsuite/extensions/BurpSuiteHTTPSmuggler/dist/lib/burp-httpsmuggler-20180711.jar

BUILD SUCCESSFUL
Total time: 2 seconds
```

Available commands:
```
$ ant -projecthelp
Buildfile: /home/burpsuite/extensions/BurpSuiteHTTPSmuggler/build.xml

Main targets:

 compile  compile the source
 dist     generate the distribution
Default target: dist
```

The structure of the build.xml file was based heavily on the examples from:  https://ant.apache.org/manual/using.html